### PR TITLE
Bug fix in VoucherConnector.Find

### DIFF
--- a/FortnoxAPILibrary/Connectors/VoucherConnector.cs
+++ b/FortnoxAPILibrary/Connectors/VoucherConnector.cs
@@ -85,7 +85,7 @@ namespace FortnoxAPILibrary.Connectors
         /// <returns>A list of vouchers</returns>
         public Vouchers Find()
         {
-            base.Resource += "/sublist/";
+            base.Resource = "vouchers/sublist";
 
             if (!string.IsNullOrEmpty(this.VoucherSeries))
             {


### PR DESCRIPTION
* A bug prevented VoucherConnector from downloading more than two pages of vouchers in a row.